### PR TITLE
Comment-out containers column from Point of Delivery view

### DIFF
--- a/src/point-of-delivery-view/point-of-delivery-view.html
+++ b/src/point-of-delivery-view/point-of-delivery-view.html
@@ -13,7 +13,7 @@
                 <th rowspan="2">{{'pointOfDeliveryView.packedBy' | message}}</th>
 
 				<th colspan="2">{{'pointOfDeliveryView.cartons' | message}}</th>
-                <th colspan="2">{{'pointOfDeliveryView.containers' | message}}</th>
+                <!--<th colspan="2">{{'pointOfDeliveryView.containers' | message}}</th>-->
 
                 <th rowspan="2">{{'pointOfDeliveryView.receivedBy' | message}}</th>
                 <th rowspan="2" class="col-sticky sticky-right">{{'pointOfDeliveryView.receivedDate' | message}}</th>
@@ -25,8 +25,8 @@
 				<th>{{'pointOfDeliveryView.quantityOnWayBill' | message}}</th>
                 <th>{{'pointOfDeliveryView.quantityAccepted' | message}}</th>
 
-				<th>{{'pointOfDeliveryView.quantityOnWayBill' | message}}</th>
-                <th>{{'pointOfDeliveryView.quantityAccepted' | message}}</th>
+				<!--<th>{{'pointOfDeliveryView.quantityOnWayBill' | message}}</th>-->
+                <!--<th>{{'pointOfDeliveryView.quantityAccepted' | message}}</th>-->
             </tr>
         </thead>
         <tbody>
@@ -37,8 +37,8 @@
                 <td>{{item.packedBy}}</td>
                 <td>{{item.cartonsQuantityOnWaybill}}</td>
                 <td>{{item.cartonsQuantityAccepted}}</td>
-                <td>{{item.containersQuantityOnWaybill}}</td>
-                <td>{{item.containersQuantityAccepted}}</td>
+                <!--<td>{{item.containersQuantityOnWaybill}}</td>-->
+                <!--<td>{{item.containersQuantityAccepted}}</td>-->
                 <td>{{formatPODrecievedBy(item.receivedByUserNames)}}</td>
                 <td>{{item.receivingDate | openlmisDate}}</td>
                 <td ng-if="item.discrepancies.length > 0" ><button class="primary"  ng-click="vm.viewDiscrepancies(item.discrepancies, item.referenceNumber)">{{'pointOfDeliveryView.discrepancies' | message}}</button></td>
@@ -49,4 +49,6 @@
     </table>
     <openlmis-pagination/>
 </section>
+
+
 


### PR DESCRIPTION
The column has been commented out (not deleted) so it can be easily restored once the containers data becomes available.