### PR TITLE
Fix/requisition filter acknowledged approved

### DIFF
--- a/src/stock-receive/stock-receive.routes.js
+++ b/src/stock-receive/stock-receive.routes.js
@@ -51,9 +51,17 @@
                 requisitionsToReceive: function(requisitionService, facility) {
                     return requisitionService.search(false, {
                         facility: facility.id,
-                        initiatedDateFrom: new Date(new Date().setDate(new Date().getDate() - 90)).toISOString().split('T')[0] //Pull requisitions initiated in the last 90 days
+                        initiatedDateFrom: new Date(new Date().setDate(new Date().getDate() - 90)).toISOString().split('T')[0],
+                        requisitionStatus: 'APPROVED'
                     }).then(function(response) {
-                        return response.content;
+                        var approved = response.content;
+                        return requisitionService.search(false, {
+                            facility: facility.id,
+                            initiatedDateFrom: new Date(new Date().setDate(new Date().getDate() - 90)).toISOString().split('T')[0],
+                            requisitionStatus: 'RELEASED'  
+                        }).then(function(response) {
+                            return approved.concat(response.content);
+                        });
                     });
                 },
                 adjustmentType: function(facility, requisitionsToReceive) {

--- a/src/stock-receive/stock-receive.routes.js
+++ b/src/stock-receive/stock-receive.routes.js
@@ -52,13 +52,15 @@
                     return requisitionService.search(false, {
                         facility: facility.id,
                         initiatedDateFrom: new Date(new Date().setDate(new Date().getDate() - 90)).toISOString().split('T')[0],
-                        requisitionStatus: 'APPROVED'
+                        requisitionStatus: 'APPROVED',
+                        emergency: false
                     }).then(function(response) {
                         var approved = response.content;
                         return requisitionService.search(false, {
                             facility: facility.id,
                             initiatedDateFrom: new Date(new Date().setDate(new Date().getDate() - 90)).toISOString().split('T')[0],
-                            requisitionStatus: 'RELEASED'  
+                            requisitionStatus: 'RELEASED',
+                            emergency: false  
                         }).then(function(response) {
                             return approved.concat(response.content);
                         });

--- a/src/stock-receive/stock-receive.routes.js
+++ b/src/stock-receive/stock-receive.routes.js
@@ -48,6 +48,7 @@
                 programs: function(user, stockProgramUtilService) {
                     return stockProgramUtilService.getPrograms(user.user_id, STOCKMANAGEMENT_RIGHTS.STOCK_ADJUST);
                 },
+                //Make 2 API calls for the different statuses
                 requisitionsToReceive: function(requisitionService, facility) {
                     return requisitionService.search(false, {
                         facility: facility.id,
@@ -55,14 +56,15 @@
                         requisitionStatus: 'APPROVED',
                         emergency: false
                     }).then(function(response) {
-                        var approved = response.content;
+                        var approved = response.content.filter(function(r) { return !r.emergency; });
                         return requisitionService.search(false, {
                             facility: facility.id,
                             initiatedDateFrom: new Date(new Date().setDate(new Date().getDate() - 90)).toISOString().split('T')[0],
-                            requisitionStatus: 'RELEASED',
-                            emergency: false  
+                            requisitionStatus: 'RELEASED',  //Released is shown as Acknowledged
+                            emergency: false
                         }).then(function(response) {
-                            return approved.concat(response.content);
+                            var released = response.content.filter(function(r) { return !r.emergency; });
+                            return approved.concat(released);
                         });
                     });
                 },


### PR DESCRIPTION
Problem:
Receive screen shows all requisitions including non-approved and emergency ones.

Solution:
Filter requisitions in stock-receive.routes.js to show only:
- Status: APPROVED or ACKNOWLEDGED
- Exclude emergency requisitions

Files changed:
- stock-receive.routes.js
