### PR TITLE
Change of requisition Header title names

### DIFF
--- a/src/branding-lesotho/messages_en.json
+++ b/src/branding-lesotho/messages_en.json
@@ -69,5 +69,8 @@
   "adminRoleForm.requisitionView": "View Requisition",
   "adminRoleForm.supervision.description": "Provides rights for managing Requisitions.",
   "adminRoleForm.supervision.label": "Requisition",
-  "adminRoleForm.dhis2Management": "Manage DHIS2 integration"
+  "adminRoleForm.dhis2Management": "Manage DHIS2 integration",
+  "requisitionView.facility": "Facility Details",
+  "requisitionView.district": "Facility Name",
+  "requisitionView.region": "District"
 }


### PR DESCRIPTION
In Requisition, A requisition header should Map “District” to District Name, not facility name. 

On the headers, we changed facility -> Facility Details, changed  District -> Facility Name and changed Region -> District.