### PR TITLE
Fix shipment quantity token collision

### DIFF
--- a/src/shipment-view/quantity-unit-toggle.controller.js
+++ b/src/shipment-view/quantity-unit-toggle.controller.js
@@ -4,15 +4,15 @@
 
     angular
         .module('shipment-view')
-        .controller('QuantityUnitToggleController', QuantityUnitToggleController);
+        .controller('ShipmentQuantityTypeToggleController', ShipmentQuantityTypeToggleController);
 
-    QuantityUnitToggleController.$inject = [
-        'messageService', 'QUANTITY_UNIT', 'localStorageService'
+    ShipmentQuantityTypeToggleController.$inject = [
+        'messageService', 'SHIPMENT_QUANTITY_TYPE', 'localStorageService'
     ];
 
     var QUANTITY_UNIT_KEY = 'shipmentFillQuantityUnit';
 
-    function QuantityUnitToggleController(messageService, QUANTITY_UNIT, localStorageService) {
+    function ShipmentQuantityTypeToggleController(messageService, SHIPMENT_QUANTITY_TYPE, localStorageService) {
 
         var vm = this;
 
@@ -22,15 +22,18 @@
 
         function onInit() {
             vm.quantityUnits = [
-                QUANTITY_UNIT.PACKS,
-                QUANTITY_UNIT.UNITS
+                SHIPMENT_QUANTITY_TYPE.PACKS,
+                SHIPMENT_QUANTITY_TYPE.UNITS
             ];
 
-            vm.quantityUnit = getCachedQuantityUnit(localStorageService.get(QUANTITY_UNIT_KEY), QUANTITY_UNIT);
+            vm.quantityUnit = getCachedQuantityUnit(
+                localStorageService.get(QUANTITY_UNIT_KEY),
+                SHIPMENT_QUANTITY_TYPE
+            );
         }
 
         function getMessage(unit) {
-            return messageService.get(QUANTITY_UNIT.$getDisplayName(unit));
+            return messageService.get(SHIPMENT_QUANTITY_TYPE.$getDisplayName(unit));
         }
 
         function onChange() {
@@ -38,11 +41,12 @@
         }
     }
 
-    function getCachedQuantityUnit(cachedQuantityUnit, QUANTITY_UNIT) {
-        if (cachedQuantityUnit === QUANTITY_UNIT.PACKS || cachedQuantityUnit === QUANTITY_UNIT.UNITS) {
+    function getCachedQuantityUnit(cachedQuantityUnit, SHIPMENT_QUANTITY_TYPE) {
+        if (cachedQuantityUnit === SHIPMENT_QUANTITY_TYPE.PACKS ||
+            cachedQuantityUnit === SHIPMENT_QUANTITY_TYPE.UNITS) {
             return cachedQuantityUnit;
         }
 
-        return QUANTITY_UNIT.PACKS;
+        return SHIPMENT_QUANTITY_TYPE.PACKS;
     }
 })();

--- a/src/shipment-view/quantity-unit.constant.js
+++ b/src/shipment-view/quantity-unit.constant.js
@@ -4,7 +4,7 @@
 
     angular
         .module('shipment-view')
-        .constant('QUANTITY_UNIT', units());
+        .constant('SHIPMENT_QUANTITY_TYPE', units());
 
     function units() {
         var values = {

--- a/src/shipment-view/shipment-view.controller.js
+++ b/src/shipment-view/shipment-view.controller.js
@@ -8,13 +8,13 @@
 
     ShipmentViewController.$inject = [
         'shipment', 'loadingModalService', '$state', '$window', 'fulfillmentUrlFactory',
-        'messageService', 'accessTokenFactory', 'updatedOrder', 'QUANTITY_UNIT', 'tableLineItems',
+        'messageService', 'accessTokenFactory', 'updatedOrder', 'SHIPMENT_QUANTITY_TYPE', 'tableLineItems',
         'VVM_STATUS'
     ];
 
     function ShipmentViewController(shipment, loadingModalService, $state, $window,
                                     fulfillmentUrlFactory, messageService, accessTokenFactory,
-                                    updatedOrder, QUANTITY_UNIT, tableLineItems, VVM_STATUS) {
+                                    updatedOrder, SHIPMENT_QUANTITY_TYPE, tableLineItems, VVM_STATUS) {
 
         var vm = this;
 
@@ -107,8 +107,8 @@
 
         function getQuantityTypeOptions() {
             return [
-                QUANTITY_UNIT.PACKS,
-                QUANTITY_UNIT.UNITS
+                SHIPMENT_QUANTITY_TYPE.PACKS,
+                SHIPMENT_QUANTITY_TYPE.UNITS
             ];
         }
 


### PR DESCRIPTION
This PR updates shipment fulfillment to support entering shipped quantities per line item in either packs or dispensing units.

It adds shipment-specific quantity type handling in the fulfillment flow, updates the shipment UI to support packs/units entry with improved layout and calculated totals, and fixes the bottom toolbar overlap so the last fulfillment row remains visible. It also includes a follow-up fix for a regression where the shared packs/units toggle disappeared in other flows. That issue was caused by a shipment-specific quantity token colliding with the shared app-wide QUANTITY_UNIT, and was resolved by isolating the shipment feature behind its own local token.

Tested by rebuilding the UI, building the image, and manually verifying:
- shipment fulfillment in packs
- shipment fulfillment in dispensing units
- mixed quantity entry
- restored shared quantity toggle behavior in other views