### PR TITLE
fix: auto-fill total carton number when reference number is selected and persist requisition selection across page refresh in receive workflow

### DIFF
--- a/src/stock-adjustment-creation/adjustment-creation.controller.js
+++ b/src/stock-adjustment-creation/adjustment-creation.controller.js
@@ -524,6 +524,17 @@
         }
     };
 
+    vm.referenceNumberChanged = function() {
+        for (var i = 0; i < ReferenceNumbers.length; i++) {
+            if (ReferenceNumbers[i].referenceNumber === vm.referenceNumber) {
+                vm.addedLineItems.forEach(function(lineItem) {
+                    lineItem.totalCartonNumber =
+                        ReferenceNumbers[i].cartonsQuantityAccepted;
+                });
+            }
+        }
+    };
+
 
     /**
      * @ngdoc method
@@ -1058,7 +1069,8 @@
                   // Put special options first, then sorted real batches
                   lots = specialLots.concat(realLots);
                   var item = orderableGroup[0];
-                  item.requisition = $stateParams.requisitionToReceiveAgainst.id;
+                  item.requisition = $stateParams.requisitionToReceiveAgainst.id
+                      || $stateParams.requisitionToReceiveAgainst;
                   vm.addedLineItems.push(_.extend({
                       $errors: {},
                       $previewSOH: item.stockOnHand

--- a/src/stock-adjustment-creation/adjustment-creation.html
+++ b/src/stock-adjustment-creation/adjustment-creation.html
@@ -17,7 +17,9 @@
             <div class="form-inline" ng-if="vm.showDeliveryNoteAttributes && !vm.servicePointUser">
                 <label for="referenceNumberSelect">{{vm.key('referenceNumber') | message}}</label>
                 <select id="referenceNumberSelect" ng-model="vm.referenceNumber"
-                    ng-options="value for value in vm.references" required>
+                    ng-options="value for value in vm.references"
+                    ng-change="vm.referenceNumberChanged()"
+                    required>
                 </select>
             </div>
             <form class="form-inline" ng-submit="vm.addProduct()" name="productForm">

--- a/src/stock-adjustment/stock-adjustment.controller.js
+++ b/src/stock-adjustment/stock-adjustment.controller.js
@@ -144,7 +144,7 @@
                 program: vm.program,
                 facility: vm.facility,
                 supervised: vm.isSupervised,
-                requisitionToReceiveAgainst: vm.requisitionToReceiveAgainst
+                requisitionToReceiveAgainst: vm.requisitionToReceiveAgainst.id
              });
             }
             

--- a/src/stock-receive-creation/receive-creation.routes.js
+++ b/src/stock-receive-creation/receive-creation.routes.js
@@ -25,7 +25,7 @@
     function routes($stateProvider, STOCKMANAGEMENT_RIGHTS, SEARCH_OPTIONS, ADJUSTMENT_TYPE) {
         $stateProvider.state('openlmis.stockmanagement.receive.creation', {
             isOffline: true,
-            url: '/:programId/create?page&size&keyword',
+            url: '/:programId/create?page&size&keyword&requisitionToReceiveAgainst',
             views: {
                 '@openlmis': {
                     controller: 'StockAdjustmentCreationController',
@@ -133,16 +133,18 @@
                            return references;
                         });
                 },
-                //Add a new resolve called requisitionLineItems that fetches the full requisition and returns its line items
                 requisitionLineItems: function($stateParams, requisitionService) {
-                    if ($stateParams.requisitionToReceiveAgainst) {
-                        return requisitionService.get(
-                            $stateParams.requisitionToReceiveAgainst.id
-                        ).then(function(requisition) {
-                            return requisition.requisitionLineItems || [];
-                        }).catch(function() {
-                            return [];
-                        });
+                    var requisitionId = $stateParams.requisitionToReceiveAgainst
+                        ? ($stateParams.requisitionToReceiveAgainst.id
+                            || $stateParams.requisitionToReceiveAgainst)
+                        : null;
+                    if (requisitionId) {
+                        return requisitionService.get(requisitionId)
+                            .then(function(requisition) {
+                                return requisition.requisitionLineItems || [];
+                            }).catch(function() {
+                                return [];
+                            });
                     }
                     return [];
                 },


### PR DESCRIPTION
Summary
Two fixes for the receive workflow:

1. Auto-fill carton number:
When a reference number is selected, the total carton number is automatically filled in for all auto-populated line items by extracting the existing carton logic into a reusable setTotalCartonNumber function.

2. Persist on refresh: 
The auto-populated table no longer disappears on page refresh by storing the requisition ID in the URL as a query parameter instead of memory only.

