### PR TITLE
feat: block Cyclic count when Major count is in progress

### DIFF
--- a/src/stock-physical-inventory-draft/physical-inventory-draft.routes.js
+++ b/src/stock-physical-inventory-draft/physical-inventory-draft.routes.js
@@ -47,6 +47,20 @@
             resolve: {
                 draft: function($stateParams, physicalInventoryFactory, offlineService,
                     physicalInventoryDraftCacheService, drafts) {
+
+                    if ($stateParams.physicalInventoryType === 'Cyclic') {
+                        if (!$stateParams.program || !$stateParams.facility) {
+                            return {
+                                programId: undefined,
+                                facilityId: undefined,
+                                isStarter: true,
+                                lineItems: []
+                            };
+                        }
+                        return physicalInventoryFactory
+                            .getDraft($stateParams.program.id, $stateParams.facility.id);
+                    }
+                        
                     if (offlineService.isOffline() || $stateParams.noReload) {
                         return physicalInventoryDraftCacheService.getDraft($stateParams.id);
                     }

--- a/src/stock-physical-inventory-list/messages_en.json
+++ b/src/stock-physical-inventory-list/messages_en.json
@@ -14,5 +14,6 @@
   "stockPhysicalInventory.noFacilitySelected": "Select a Facility",
   "stockPhysicalInventory.countInventory": "countInventory",
   "stockPhysicalInventory.majorCount": "Start Major Count",
-  "stockPhysicalInventory.cyclicCount": "Start Cyclic Count"
+  "stockPhysicalInventory.cyclicCount": "Start Cyclic Count",
+  "stockPhysicalInventory.majorCountInProgress": "Please complete or delete the ongoing Major count before starting a Cyclic count."
 }

--- a/src/stock-physical-inventory-list/physical-inventory-list.controller.js
+++ b/src/stock-physical-inventory-list/physical-inventory-list.controller.js
@@ -5,12 +5,12 @@
  * This program is free software: you can redistribute it and/or modify it under the terms
  * of the GNU Affero General Public License as published by the Free Software Foundation, either
  * version 3 of the License, or (at your option) any later version.
- *  
+ *  
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
  * See the GNU Affero General Public License for more details. You should have received a copy of
  * the GNU Affero General Public License along with this program. If not, see
- * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
  */
 
 (function () {
@@ -71,31 +71,22 @@
          */
         vm.programs = programs;
 
-        //vm.drafts = (vm.physicalInventoryType === "Major") ? drafts : draftsForCyclic;
-
-        //Default to Major drafts
+        // Default to Major drafts at init time.
         vm.drafts = drafts[0];
 
         $scope.$watch(function () { return vm.program; }, function (newVal, oldVal) {
-
             if (newVal === oldVal) return;
-            // if (vm.adjustmentType !== 'receive') return; // only show options in Receive flow
 
             if (newVal == null || newVal == undefined) {
-
                 return;
-
             } else {
-
                 var draft = vm.getDraft();
-               
                 if (draft && draft.id) {
                     draft.isStarter = false;
                     return draft;
                 }
             }
         });
-
 
         vm.editDraft = new FunctionDecorator()
             .decorateFunction(editDraft)
@@ -106,13 +97,8 @@
             if (!vm.program || !vm.facility) {
                 return null;
             }
-            // else if (!vm.facility) {
-            //     alertService.error('stockPhysicalInventory.noFacilitySelected');
-            // }
             var programId = vm.program.id;
             return _.find(vm.drafts, function (draft) {
-                // console.log("Program: ", vm.program);
-                // console.log("Draft: ", draft);
                 return draft.programId === programId;
             });
         };
@@ -122,7 +108,7 @@
             return _.find(vm.drafts, function (draft) {
                 return draft.programId === programId;
             });
-        }
+        };
 
         /**
          * @ngdoc method
@@ -155,12 +141,20 @@
                 return messageService.get('stockPhysicalInventory.notStarted');
             }
             return messageService.get('stockPhysicalInventory.draft');
-
         };
 
+        /**
+         * @ngdoc method
+         * @propertyOf stock-physical-inventory-list.controller:PhysicalInventoryListController
+         * @name onChangePhysicalInventoryType
+         *
+         * @description
+         * Updates vm.drafts when the user toggles between Major and Cyclic inventory types.
+         * drafts[0] is Major drafts, drafts[1] is Cyclic drafts.
+         */
         vm.onChangePhysicalInventoryType = function () {
             vm.drafts = (vm.physicalInventoryType === "Major") ? drafts[0] : drafts[1];
-        }
+        };
 
         /**
          * @ngdoc method
@@ -168,24 +162,65 @@
          * @name editDraft
          *
          * @description
-         * Navigating to draft physical inventory.
+         * Navigates to draft physical inventory.
+         *
+         * For Cyclic counts, queries the server live to check if a Major count is
+         * in progress for the same facility and program before allowing navigation.
+         * "In progress" means the server draft exists AND has at least one line item
+         * with a real quantity entered (not null, not -1). A draft at 0% progress
+         * does not block the Cyclic count.
+         *
+         * The server is queried live so the check reflects the current state even
+         * after a Major draft was deleted — avoids relying on stale in-memory drafts.
          *
          * @param {Object} draft Physical inventory draft
          */
         function editDraft(draft) {
-            // console.log("Edit: ", draft);
-            // console.log("Drafts: ", vm.drafts);
-            // console.log("Program: ", vm.program);
-            // console.log("Facility: ", vm.facility);
-            // console.log("Selected:" , vm.getDraft());
             $stateParams.stateOffline = setOfflineState();
+
             if (!draft) {
                 alertService.error('No draft found');
-                return;
+                return $q.reject();
             }
 
-            // Get the draft , prefer passed draft, 
-            // then find existing, else create new
+            // Cyclic path — check server live for a Major count in progress before
+            // allowing navigation. physicalInventoryService.getDraft is used directly
+            // (not the factory) to get the raw server response with lineItems and
+            // quantities. vm.program.id and vm.facility.id are always the currently
+            // selected values from openlmis-facility-program-select two-way binding,
+            // so supervised facilities are handled correctly.
+            if (vm.physicalInventoryType === 'Cyclic') {
+                return physicalInventoryService.getDraft(vm.program.id, vm.facility.id)
+                    .then(function(serverDrafts) {
+                        if (!Array.isArray(serverDrafts) ||
+                            serverDrafts.length === 0 ||
+                            !serverDrafts[0].id) {
+                            // No Major draft on server — Cyclic is allowed.
+                            return navigateToCyclic(draft);
+                        }
+
+                        // A Major draft exists. Only block if it has real progress —
+                        // at least one line item with a quantity entered (not null,
+                        // not -1). A draft at 0% is treated as not started.
+                        var lineItems = serverDrafts[0].lineItems || [];
+                        var hasProgress = lineItems.some(function(item) {
+                            return item.quantity !== null &&
+                                item.quantity !== undefined &&
+                                item.quantity !== -1;
+                        });
+
+                        if (hasProgress) {
+                            alertService.error('stockPhysicalInventory.majorCountInProgress');
+                            // Return $q.reject() so FunctionDecorator closes the
+                            // loading modal cleanly without keeping spinner running.
+                            return $q.reject();
+                        }
+
+                        return navigateToCyclic(draft);
+                    });
+            }
+
+            // Major path — original logic unchanged.
             var selectedDraft = draft || vm.getDraft();
 
             vm.drafts.forEach(function (item) {
@@ -193,6 +228,7 @@
                     item.isStarter = false;
                 }
             });
+
             if (offlineService.isOffline() || selectedDraft.id) {
                 $state.go('openlmis.stockmanagement.physicalInventory.draft', {
                     id: selectedDraft.id,
@@ -205,50 +241,70 @@
                 return $q.resolve();
             }
 
-            return physicalInventoryService.getDraft(vm.program.id, vm.facility.id).then(function (data) {
+            return physicalInventoryService.getDraft(vm.program.id, vm.facility.id)
+                .then(function (data) {
+                    if (Array.isArray(data) && data.length > 0 && data[0].id) {
+                        selectedDraft.id = data[0].id;
+                        $state.go('openlmis.stockmanagement.physicalInventory.draft', {
+                            id: selectedDraft.id,
+                            program: vm.program,
+                            facility: vm.facility,
+                            supervised: vm.isSupervised,
+                            includeInactive: false,
+                            physicalInventoryType: vm.physicalInventoryType
+                        });
+                    } else {
+                        return physicalInventoryService.createDraft(vm.program.id, vm.facility.id)
+                            .then(function (data) {
+                                selectedDraft.id = data.id;
+                                $state.go('openlmis.stockmanagement.physicalInventory.draft', {
+                                    id: selectedDraft.id,
+                                    program: vm.program,
+                                    facility: vm.facility,
+                                    supervised: vm.isSupervised,
+                                    includeInactive: false,
+                                    physicalInventoryType: vm.physicalInventoryType
+                                });
+                            });
+                    }
+                });
+        }
 
-                if (Array.isArray(data) && data.length > 0 && data[0].id) {
-                     selectedDraft.id = data[0].id;
-                        $state.go('openlmis.stockmanagement.physicalInventory.draft', {
-                            id: selectedDraft.id,
-                            program: vm.program,
-                            facility: vm.facility,
-                            supervised: vm.isSupervised,
-                            includeInactive: false,
-                            physicalInventoryType: vm.physicalInventoryType
-                        });
-                } else {
-                    return physicalInventoryService.createDraft(vm.program.id, vm.facility.id).then(function (data) {
-                        //    console.log("Data: ", data);
-                        selectedDraft.id = data.id;
-                        $state.go('openlmis.stockmanagement.physicalInventory.draft', {
-                            id: selectedDraft.id,
-                            program: vm.program,
-                            facility: vm.facility,
-                            supervised: vm.isSupervised,
-                            includeInactive: false,
-                            physicalInventoryType: vm.physicalInventoryType
-                        });
-                    });
+        /**
+         * @ngdoc method
+         * @propertyOf stock-physical-inventory-list.controller:PhysicalInventoryListController
+         * @name navigateToCyclic
+         *
+         * @description
+         * Navigates to the Cyclic count draft page. Cyclic is submit-only and has
+         * no server draft — navigates without an id and without calling createDraft.
+         * program and facility are passed as stateParams so the routes resolver can
+         * call getDraft correctly for the selected facility.
+         *
+         * @param {Object} draft Cyclic draft stub from vm.drafts
+         */
+        function navigateToCyclic(draft) {
+            var selectedDraft = draft;
+            vm.drafts.forEach(function(item) {
+                if (item.programId === selectedDraft.programId &&
+                    selectedDraft.isStarter === true) {
+                    item.isStarter = false;
                 }
-
             });
-            // return physicalInventoryService.createDraft(vm.program.id, vm.facility.id).then(function (data) {
-            //     //    console.log("Data: ", data);
-            //     selectedDraft.id = data.id;
-            //     $state.go('openlmis.stockmanagement.physicalInventory.draft', {
-            //         id: selectedDraft.id,
-            //         program: vm.program,
-            //         facility: vm.facility,
-            //         supervised: vm.isSupervised,
-            //         includeInactive: false,
-            //         physicalInventoryType: vm.physicalInventoryType
-            //     });
-            // });
+            // Cyclic has no server draft — navigate without id so the routes
+            // resolver does not try to look up a draft by id (which would fail).
+            $state.go('openlmis.stockmanagement.physicalInventory.draft', {
+                id: undefined,
+                program: vm.program,
+                facility: vm.facility,
+                supervised: vm.isSupervised,
+                includeInactive: false,
+                physicalInventoryType: vm.physicalInventoryType
+            });
+            return $q.resolve();
         }
 
         function onInit() {
-
             if (networkStateHasBeenChanged()) {
                 reloadPage();
             }
@@ -278,4 +334,3 @@
         }
     }
 })();
-


### PR DESCRIPTION
- Before navigating to a Cyclic count, queries the server live to check if a Major draft exists for the same facility and program with at least one quantity entered (not null, not -1). Blocks with an alert if so.
- A draft at 0% progress does not block the Cyclic count.
- The check is scoped to the selected facility and program so a Cyclic count for a different program or facility is not blocked.
- Returns $q.reject() so FunctionDecorator closes loading modal cleanly.
- Adds navigateToCyclic helper that navigates without an id since Cyclic has no server draft.
- Routes resolver handles Cyclic first, calling getDraft directly for the selected facility so correct stock products are loaded. Never calls getPhysicalInventory for Cyclic.
- Adds majorCountInProgress message key to messages_en.json.