### PR TITLE
fix(physical-inventory): fix cyclic and major count bugs

### DIFF
--- a/src/stock-physical-inventory-draft/physical-inventory-draft.controller.js
+++ b/src/stock-physical-inventory-draft/physical-inventory-draft.controller.js
@@ -195,8 +195,7 @@
         return;
       }
 
-      // Only include active lots — reuses the same active===true check that
-      // physicalInventoryService.search() applies internally for Major counts.
+      
       var fullGroup = draft.lineItems.filter(function(item) {
         return item.orderable.id === orderableId && item.active === true;
       });
@@ -205,12 +204,19 @@
 
       fullGroup.forEach(function(item) {
         item.isAdded = true;
-        // Do not set quantity here — leave it null for display.
-        // physicalInventoryFactory.getQuantity() will send -1 to the server
-        // when quantity is null and isAdded is true.
+
       });
 
       draft.$modified = true;
+
+      if (!draft.$serverDraftId && draft.id) {
+          draft.$serverDraftId = draft.id;
+      }
+
+      //if (!draft.id) {
+          draft.id = 'cyclic-' + draft.programId + '-' + draft.facilityId;
+      //}
+
       vm.cacheDraft();
 
       notificationService.success(messageService.get('stockPhysicalInventoryDraft.productAdded'));
@@ -501,11 +507,18 @@
           $stateParams.facility = vm.facility;
           $stateParams.noReload = true;
 
-          // Only cache for Major — Cyclic has no draft persistence
-          if ($stateParams.physicalInventoryType !== 'Cyclic') {
-            draft.$modified = true;
-            vm.cacheDraft();
+          draft.$modified = true;
+
+          if ($stateParams.physicalInventoryType === 'Cyclic') {
+              if (!draft.$serverDraftId && draft.id) {
+                  draft.$serverDraftId = draft.id;
+              }
+              
+              //if (!draft.id) {
+                  draft.id = 'cyclic-' + draft.programId + '-' + draft.facilityId;
+              //}
           }
+          vm.cacheDraft();
 
           $state.go($state.current.name, $stateParams, {
             reload: $state.current.name
@@ -655,8 +668,11 @@
                   "stockPhysicalInventoryDraft.saved"
                 );
 
-                draft.$modified = undefined;
-                vm.cacheDraft();
+                //draft.$modified = undefined;
+                //vm.cacheDraft();
+
+                // Remove the stale cache entry so the resolver fetches fresh data from the server via getPhysicalInventory.
+                physicalInventoryDraftCacheService.removeById(draft.id);
 
                 $stateParams.isAddProduct = false;
                 $stateParams.program = vm.program;
@@ -666,7 +682,7 @@
                     lineItem.$isNewItem = false;
                   }
                 });
-                $stateParams.noReload = true;
+                $stateParams.noReload = undefined;
 
                 $state.go($state.current.name, $stateParams, {
                   reload: $state.current.name
@@ -741,6 +757,22 @@
           "stockPhysicalInventoryDraft.delete"
         )
         .then(function () {
+
+          if (vm.stateParams.physicalInventoryType === 'Cyclic') {
+        // Cyclic has no server draft. Clear the local cache entry so the
+        // next Cyclic session starts fresh, then navigate back to the list.
+        // Reset $modified so the resolver does not return this stale draft.
+        draft.$modified = false;
+        vm.cacheDraft();
+        $scope.needToConfirm = false;
+        $state.go(
+          "openlmis.stockmanagement.physicalInventory",
+          $stateParams,
+          { reload: true }
+        );
+        return;
+      }
+
           loadingModalService.open();
           physicalInventoryService
             .deleteDraft(draft.id)
@@ -786,6 +818,10 @@
           draft.occurredDate = resolvedData.occurredDate;
           draft.signature = resolvedData.signature;
 
+          if (vm.stateParams.physicalInventoryType === 'Cyclic' && draft.$serverDraftId) {
+              draft.id = undefined;
+          }
+
           return saveLots(draft, function () {
             physicalInventoryService
               .submitPhysicalInventory(
@@ -812,9 +848,11 @@
                       );
                     })
                     .finally(function () {
-                      // Clear the discard confirmation flag so navigating
-                      // away after a successful submit does not show the modal.
+                      
                       $scope.needToConfirm = false;
+                      // Clear the cyclic cache after successful submit so the next session starts fresh.
+                      var cyclicKey = 'cyclic-' + draft.programId + '-' + draft.facilityId;
+                      physicalInventoryDraftCacheService.removeById(cyclicKey);
                       $state.go("openlmis.stockmanagement.stockCardSummaries", {
                         program: program.id,
                         facility: draft.facilityId,
@@ -826,7 +864,6 @@
                 function (errorResponse) {
                   loadingModalService.close();
                   alertService.error(errorResponse.data.message);
-                  physicalInventoryDraftCacheService.removeById(draft.id);
                 }
               );
           });
@@ -1126,6 +1163,7 @@
               newList,
               vm.program.id
             );
+            vm.updateProgress();
           },
           true
         );

--- a/src/stock-physical-inventory-draft/physical-inventory-draft.routes.js
+++ b/src/stock-physical-inventory-draft/physical-inventory-draft.routes.js
@@ -47,6 +47,42 @@
             resolve: {
                 draft: function($stateParams, physicalInventoryFactory, offlineService,
                     physicalInventoryDraftCacheService, drafts) {
+
+                    // Cyclic is handled first — it has no server draft and no id.
+                    // Both noReload and normal load use the same path: check cache
+                    // using a synthetic key (program+facility), then fall back to
+                    // getDraft for a fresh server fetch on first load.
+                    // Never call getPhysicalInventory for Cyclic — it would load the
+                    // Major draft's line items since they share the same server draft id.
+                    if ($stateParams.physicalInventoryType === 'Cyclic') {
+                        if (!$stateParams.program || !$stateParams.facility) {
+                            return {
+                                programId: undefined,
+                                facilityId: undefined,
+                                isStarter: true,
+                                lineItems: []
+                            };
+                        }
+                        // Synthetic cache key — Cyclic has no server draft id so we
+                        // use program+facility as a stable identifier. vm.addProducts
+                        // sets draft.id to this same key before calling cacheDraft().
+                        var cyclicKey = 'cyclic-' +
+                            $stateParams.program.id + '-' +
+                            $stateParams.facility.id;
+                        return physicalInventoryDraftCacheService.getDraft(cyclicKey)
+                            .then(function(cached) {
+                                if (cached && cached.$modified) {
+                                    return cached;
+                                }
+                                // No modified cache — fresh load. Call getDraft to get
+                                // real stock products for this facility so Search Existing
+                                // Product and Add from Catalogue have items to show.
+                                return physicalInventoryFactory
+                                    .getDraft($stateParams.program.id, $stateParams.facility.id);
+                            });
+                    }
+
+                    // noReload=true after Add Product or Save for Major — load from cache.
                     if (offlineService.isOffline() || $stateParams.noReload) {
                         return physicalInventoryDraftCacheService.getDraft($stateParams.id);
                     }

--- a/src/stock-physical-inventory-list/messages_en.json
+++ b/src/stock-physical-inventory-list/messages_en.json
@@ -14,5 +14,6 @@
   "stockPhysicalInventory.noFacilitySelected": "Select a Facility",
   "stockPhysicalInventory.countInventory": "countInventory",
   "stockPhysicalInventory.majorCount": "Start Major Count",
-  "stockPhysicalInventory.cyclicCount": "Start Cyclic Count"
+  "stockPhysicalInventory.cyclicCount": "Start Cyclic Count",
+  "stock.PhysicalInventory.majorCountInProgress": "Please complete or delete the ongoing Major count before stating a Cyclic count."
 }

--- a/src/stock-physical-inventory-list/physical-inventory-list.controller.js
+++ b/src/stock-physical-inventory-list/physical-inventory-list.controller.js
@@ -111,8 +111,6 @@
             // }
             var programId = vm.program.id;
             return _.find(vm.drafts, function (draft) {
-                // console.log("Program: ", vm.program);
-                // console.log("Draft: ", draft);
                 return draft.programId === programId;
             });
         };
@@ -173,15 +171,45 @@
          * @param {Object} draft Physical inventory draft
          */
         function editDraft(draft) {
-            // console.log("Edit: ", draft);
-            // console.log("Drafts: ", vm.drafts);
-            // console.log("Program: ", vm.program);
-            // console.log("Facility: ", vm.facility);
-            // console.log("Selected:" , vm.getDraft());
             $stateParams.stateOffline = setOfflineState();
+
             if (!draft) {
                 alertService.error('No draft found');
-                return;
+                return $q.reject();
+            }
+
+            // Cyclic path — check server live for a Major count in progress before
+            // allowing navigation. physicalInventoryService.getDraft is used directly
+            // (not the factory) to get the raw server response with lineItems and
+            // quantities. vm.program.id and vm.facility.id are always the currently
+            // selected values from openlmis-facility-program-select two-way binding,
+            // so supervised facilities are handled correctly.
+            if (vm.physicalInventoryType === 'Cyclic') {
+                return physicalInventoryService.getDraft(vm.program.id, vm.facility.id)
+                    .then(function(serverDrafts) {
+                        if (!Array.isArray(serverDrafts) ||
+                            serverDrafts.length === 0 ||
+                            !serverDrafts[0].id) {
+                            // No Major draft on server -> Cyclic is allowed.
+                            return navigateToCyclic(draft);
+                        }
+
+                        // A Major draft exists. Only block if it has real progress
+                        var lineItems = serverDrafts[0].lineItems || [];
+                        var hasProgress = lineItems.some(function(item) {
+                            return item.quantity !== null &&
+                                item.quantity !== undefined &&
+                                item.quantity !== -1; //&&
+                                //item.quantity !== 0;
+                        });
+
+                        if (hasProgress) {
+                            alertService.error('stockPhysicalInventory.majorCountInProgress');
+                            return $q.reject();
+                        }
+
+                        return navigateToCyclic(draft);
+                    });
             }
 
             // Get the draft , prefer passed draft, 
@@ -219,7 +247,6 @@
                         });
                 } else {
                     return physicalInventoryService.createDraft(vm.program.id, vm.facility.id).then(function (data) {
-                        //    console.log("Data: ", data);
                         selectedDraft.id = data.id;
                         $state.go('openlmis.stockmanagement.physicalInventory.draft', {
                             id: selectedDraft.id,
@@ -245,6 +272,25 @@
             //         physicalInventoryType: vm.physicalInventoryType
             //     });
             // });
+        }
+        
+        function navigateToCyclic(draft) {
+            var selectedDraft = draft;
+            vm.drafts.forEach(function(item) {
+                if (item.programId === selectedDraft.programId &&
+                    selectedDraft.isStarter === true) {
+                    item.isStarter = false;
+                }
+            });
+            $state.go('openlmis.stockmanagement.physicalInventory.draft', {
+                id: undefined,
+                program: vm.program,
+                facility: vm.facility,
+                supervised: vm.isSupervised,
+                includeInactive: false,
+                physicalInventoryType: vm.physicalInventoryType
+            });
+            return $q.resolve();
         }
 
         function onInit() {

--- a/src/stock-physical-inventory/physical-inventory.factory.js
+++ b/src/stock-physical-inventory/physical-inventory.factory.js
@@ -119,10 +119,6 @@
                         isStarter: true,
                         lineItems: []
                     };
-                    if (draftExists(response)) {
-                        draftToReturn.id = response[0].id;
-                    }
-                    return draftToReturn;
                 });
         }
 


### PR DESCRIPTION
Fixes all remaining bugs in the physical inventory module across both Cyclic and Major count flows.

Cyclic count
- Add From Catalogue and Search Existing Product now correctly populate the table for both home and supervised facilities
- There is an alert message that is shown when a user tries to do a cyclic count while a major count is in progress for the same facility and program
- Navigation to Cyclic count no longer crashes when no Major draft is in progress


Major count
- Save Draft now persists edits correctly when returning to the draft after navigating away
- Progress bar now updates correctly as products are counted
- Add Products in supervised facility now loads the correct facility's products instead of the home facility's