### PR TITLE
Show 'Continue Major Count' button label when major count is in progress

### DIFF
--- a/src/stock-physical-inventory-list/messages_en.json
+++ b/src/stock-physical-inventory-list/messages_en.json
@@ -15,5 +15,6 @@
   "stockPhysicalInventory.countInventory": "countInventory",
   "stockPhysicalInventory.majorCount": "Start Major Count",
   "stockPhysicalInventory.cyclicCount": "Start Cyclic Count",
+  "stockPhysicalInventory.continueMajorCount": "Continue Major Count",
   "stock.PhysicalInventory.majorCountInProgress": "Please complete or delete the ongoing Major count before stating a Cyclic count."
 }

--- a/src/stock-physical-inventory-list/physical-inventory-list.controller.js
+++ b/src/stock-physical-inventory-list/physical-inventory-list.controller.js
@@ -63,6 +63,18 @@
         /**
          * @ngdoc property
          * @propertyOf stock-physical-inventory-list.controller:PhysicalInventoryListController
+         * @name majorCountInProgress
+         * @type {Boolean}
+         *
+         * @description
+         * Indicates whether a Major count with real progress exists for the selected
+         * program and facility. Set by the program watcher when a program is selected.
+         */
+        vm.majorCountInProgress = false;
+
+        /**
+         * @ngdoc property
+         * @propertyOf stock-physical-inventory-list.controller:PhysicalInventoryListController
          * @name programs
          * @type {Array}
          *
@@ -83,6 +95,7 @@
 
             if (newVal == null || newVal == undefined) {
 
+                vm.majorCountInProgress = false;
                 return;
 
             } else {
@@ -91,8 +104,20 @@
 
                 if (draft && draft.id) {
                     draft.isStarter = false;
-                    return draft;
                 }
+
+                physicalInventoryService.getDraft(newVal.id, vm.facility.id)
+                    .then(function(serverDrafts) {
+                        var hasProgress = Array.isArray(serverDrafts) &&
+                            serverDrafts.length > 0 &&
+                            serverDrafts[0].id &&
+                            (serverDrafts[0].lineItems || []).some(function(item) {
+                                return item.quantity !== null &&
+                                    item.quantity !== undefined &&
+                                    item.quantity !== -1;
+                            });
+                        vm.majorCountInProgress = hasProgress;
+                    });
             }
         });
 
@@ -158,6 +183,7 @@
 
         vm.onChangePhysicalInventoryType = function () {
             vm.drafts = (vm.physicalInventoryType === "Major") ? drafts[0] : drafts[1];
+            vm.majorCountInProgress = false;
         }
 
         /**
@@ -336,4 +362,3 @@
         }
     }
 })();
-

--- a/src/stock-physical-inventory-list/physical-inventory-list.html
+++ b/src/stock-physical-inventory-list/physical-inventory-list.html
@@ -22,15 +22,12 @@
       value="{{'stockPhysicalInventory.start' | message}}" class="primary"/>
   </div> -->
   <input ng-if="vm.physicalInventoryType === 'Major'" id="proceedButton" type="button" ng-click="vm.editDraft(vm.getSelectedDraft())"
-       value="{{(vm.getSelectedDraft() && vm.getSelectedDraft().isStarter ? 'stockPhysicalInventory.start' : 'stockPhysicalInventory.majorCount') | message}}"
+       value="{{(vm.majorCountInProgress ? 'stockPhysicalInventory.continueMajorCount' : 'stockPhysicalInventory.majorCount') | message}}"
        class="primary"/>
   <input ng-if="vm.physicalInventoryType === 'Cyclic'"
        id="proceedButton"
        type="button"
        ng-click="vm.editDraft(vm.getSelectedDraft())"
-       value="{{'stockPhysicalInventory.cyclicCount' | message}}"
+       value="{{(vm.majorCountInProgress ? 'stockPhysicalInventory.continueMajorCount' : 'stockPhysicalInventory.cyclicCount') | message}}"
        class="primary"/>
 </form>
-
-
-


### PR DESCRIPTION
- Add vm.majorCountInProgress flag to PhysicalInventoryListController
- Extend program watcher to call physicalInventoryService.getDraft() and detect real progress (quantity !== null/undefined/-1) on program select
- Reset vm.majorCountInProgress on inventory type toggle change
- Update Major and Cyclic buttons in HTML to use vm.majorCountInProgress instead of isStarter for button label resolution
- Add stockPhysicalInventory.continueMajorCount message key
- Fix pre-existing typo in stockPhysicalInventory.majorCountInProgress key