### PR TITLE
Fix blank page on refresh in Major and Cyclic physical inventory draft

### DIFF
--- a/src/stock-physical-inventory-draft/physical-inventory-draft.routes.js
+++ b/src/stock-physical-inventory-draft/physical-inventory-draft.routes.js
@@ -56,6 +56,12 @@
                     // Major draft's line items since they share the same server draft id.
                     if ($stateParams.physicalInventoryType === 'Cyclic') {
                         if (!$stateParams.program || !$stateParams.facility) {
+                            // On refresh, program and facility are lost from stateParams.
+                            // Cyclic has no id in the URL so we cannot look up by id.
+                            // The cache key is cyclic-{programId}-{facilityId} but we
+                            // don't know either value here. Return an empty draft —
+                            // the program and facility resolves below will recover what
+                            // they can, and the page will render in its blank start state.
                             return {
                                 programId: undefined,
                                 facilityId: undefined,
@@ -80,6 +86,15 @@
                                 return physicalInventoryFactory
                                     .getDraft($stateParams.program.id, $stateParams.facility.id);
                             });
+                    }
+
+                    // On refresh for Major: program and facility are lost from stateParams
+                    // but id is always in the URL. Load directly from the cache which
+                    // holds the full draft object including programId and facilityId.
+                    // physicalInventoryFactory.getPhysicalInventory needs both program
+                    // and facility to load stock summaries — the cache avoids that call.
+                    if (!$stateParams.program || !$stateParams.facility) {
+                        return physicalInventoryDraftCacheService.getDraft($stateParams.id);
                     }
 
                     // noReload=true after Add Product or Save for Major — load from cache.


### PR DESCRIPTION
- Major refresh: recover draft from cache using id from URL when program and facility are missing from stateParams. Avoids crashing call to getPhysicalInventory which requires programId and facilityId to load stock card summaries. Program and facility resolves recover downstream from draft.programId and getUserHomeFacility() as designed.

- Cyclic refresh: retain empty draft stub with clarifying comment. Cyclic has no id in the URL and no server persistence, so the cache key (cyclic-{programId}-{facilityId}) cannot be reconstructed on refresh. Page renders in blank start state rather than throwing an error.