### PR TITLE
Removed the model mutation in validateUnitPrice that was overwriting …

### DIFF
--- a/src/stock-adjustment-creation/adjustment-creation.controller.js
+++ b/src/stock-adjustment-creation/adjustment-creation.controller.js
@@ -666,7 +666,6 @@
         if (isNaN(price) || price < 0) {
           lineItem.$errors.unitPriceInvalid = messageService.get('stockAdjustmentCreation.unitPriceInvalid');
         } else {
-          lineItem.unitPrice = price;
           lineItem.$errors.unitPriceInvalid = false;
         }
       }


### PR DESCRIPTION
…the typed value with parseFloat() on every keystroke, which stripped the

decimal point and made it impossible to enter values like 10.01.